### PR TITLE
Refactor: Reorganize core components and key management

### DIFF
--- a/constants/keys.go
+++ b/constants/keys.go
@@ -1,0 +1,32 @@
+package elk_coordinator
+
+// Key format string constants used across the coordinator.
+// These define the structure of keys stored in the data store (e.g., Redis).
+// Using '%s' for namespace substitution where applicable.
+const (
+	// HeartbeatKeyFormat is the format for worker heartbeat keys.
+	// Usage: fmt.Sprintf(HeartbeatKeyFormat, namespace, workerID)
+	HeartbeatKeyFormat = "elk_coord/%s/heartbeats/%s"
+
+	// WorkersKeyFormat is the format for the key storing the set of active workers.
+	// Usage: fmt.Sprintf(WorkersKeyFormat, namespace)
+	WorkersKeyFormat = "elk_coord/%s/workers"
+
+	// LeaderKeyFormat is the format for the leader election lock key.
+	// Usage: fmt.Sprintf(LeaderKeyFormat, namespace)
+	LeaderKeyFormat = "elk_coord/%s/leader"
+
+	// PartitionLockKeyFormat is the format for partition-specific lock keys.
+	// Usage: fmt.Sprintf(PartitionLockKeyFormat, namespace, partitionID)
+	PartitionLockKeyFormat = "elk_coord/%s/locks/partition/%d"
+
+	// PartitionInfoKeyFormat is the format for the key storing all partition information.
+	// Usage: fmt.Sprintf(PartitionInfoKeyFormat, namespace)
+	PartitionInfoKeyFormat = "elk_coord/%s/partitions_info"
+
+	// TaskStatusKeyFormat is a generic example if task statuses were stored individually.
+	// Not currently used by the provided snippets but shown as an example.
+	// TaskStatusKeyFormat = "elk_coord/%s/tasks/%s/status"
+
+	// Add other key formats here as needed.
+)

--- a/leader_election.go
+++ b/leader_election.go
@@ -1,0 +1,313 @@
+package elk_coordinator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+// Store defines the interface for a data store that can be used for leader election.
+// It's a subset of methods from data.DataStore, tailored for leader election needs.
+type Store interface {
+	// AcquireLock attempts to acquire a lock (SetNX behavior).
+	// Returns true if the lock was acquired.
+	AcquireLock(ctx context.Context, key string, value string, expiry time.Duration) (bool, error)
+	// RenewLock attempts to renew an existing lock.
+	// Returns true if the lock was renewed.
+	RenewLock(ctx context.Context, key string, value string, expiry time.Duration) (bool, error)
+	// GetLockOwner retrieves the current owner of the lock.
+	// If the lock does not exist or is expired, it might return an empty string or an error.
+	GetLockOwner(ctx context.Context, key string) (string, error)
+	// ReleaseLock releases a lock.
+	ReleaseLock(ctx context.Context, key string, value string) error
+}
+
+// LeaderElector handles the leader election process for an instance.
+type LeaderElector struct {
+	instanceID string
+	namespace  string
+	store      Store // The data store for lock operations
+
+	// Leader election configuration
+	// leaderKeyFmt is now the global LeaderKeyFormat constant
+	leaderLockExpiry     time.Duration // How long the leader lock is valid
+	leaderElectionInterval time.Duration // How often to check/try for leadership
+
+	log *logrus.Entry // Structured logger
+
+	mu           sync.Mutex
+	isLeader     bool
+	leaderCtx    context.Context    // Context for the current leadership term
+	cancelLeader context.CancelFunc // Cancels the leaderCtx
+}
+
+// NewLeaderElector creates and returns a new LeaderElector.
+// keyFmt argument is removed, will use global LeaderKeyFormat.
+func NewLeaderElector(
+	instanceID string,
+	namespace string,
+	store Store,
+	log *logrus.Entry,
+	lockExpiry time.Duration,
+	electionInterval time.Duration,
+) *LeaderElector {
+	// Ensure logger is not nil
+	actualLog := log
+	if actualLog == nil {
+		actualLog = logrus.NewEntry(logrus.New()) // Fallback to a default logger
+		actualLog.Warn("NewLeaderElector received a nil logger, using a default one.")
+	}
+
+	return &LeaderElector{
+		instanceID:             instanceID,
+		namespace:              namespace,
+		store:                  store,
+		leaderLockExpiry:       lockExpiry,
+		leaderElectionInterval: electionInterval,
+		// leaderKeyFmt:        is now global LeaderKeyFormat
+		log:                    actualLog.WithField("component", "leader-elector").WithField("instance_id", instanceID),
+	}
+}
+
+// getLeaderKey returns the specific leader key for the configured namespace.
+func (l *LeaderElector) getLeaderKey() string {
+	return fmt.Sprintf(LeaderKeyFormat, l.namespace) // Uses global LeaderKeyFormat
+}
+
+// Lead starts the leader election loop.
+// The provided errgroup.Group can be used to manage the lifecycle of this goroutine.
+func (l *LeaderElector) Lead(ctx context.Context, g *errgroup.Group) {
+	l.log.Infof("Starting leader election process for namespace '%s'", l.namespace)
+
+	l.mu.Lock()
+	// If leaderCtx is already active from a previous call for this instance, cancel it.
+	if l.cancelLeader != nil {
+		l.log.Warn("LeaderElector.Lead called while previous leader loop might be active. Cancelling previous loop.")
+		l.cancelLeader()
+	}
+	l.leaderCtx, l.cancelLeader = context.WithCancel(ctx)
+	l.mu.Unlock()
+
+	g.Go(func() error {
+		// Defer the cleanup actions.
+		defer func() {
+			l.log.Infof("Leader election goroutine for namespace '%s' is shutting down.", l.namespace)
+			// Ensure leadership is released if this instance was the leader.
+			// Use a background context for releasing leadership as leaderCtx might be cancelled.
+			releaseCtx, cancelRelease := context.WithTimeout(context.Background(), l.leaderLockExpiry/2+time.Millisecond*100)
+			defer cancelRelease()
+			l.releaseLeadership(releaseCtx, "leader loop ended")
+
+			l.mu.Lock()
+			if l.cancelLeader != nil {
+				// l.cancelLeader() // This would cancel the context we are operating in, which is fine if error group handles it.
+				l.cancelLeader = nil // Mark as no longer active
+			}
+			l.mu.Unlock()
+		}()
+
+		l.leaderLoop(l.leaderCtx)
+		return nil // Errors are handled by logging and attempting to recover or step down.
+	})
+}
+
+// leaderLoop is the main loop for leader election.
+func (l *LeaderElector) leaderLoop(ctx context.Context) {
+	l.log.Debug("Leader loop started.")
+	// Attempt to become leader immediately on start.
+	// Use a short timeout for the initial attempt.
+	initialAttemptCtx, initialCancel := context.WithTimeout(ctx, l.leaderElectionInterval/2)
+	l.attemptElectionOrRenewal(initialAttemptCtx)
+	initialCancel() // Release resources of initialAttemptCtx
+
+	ticker := time.NewTicker(l.leaderElectionInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			l.log.Infof("Leader election context cancelled. Reason: %v. Exiting leader loop.", ctx.Err())
+			return
+		case <-ticker.C:
+			if ctx.Err() != nil { // Check if context was cancelled during tick wait
+				l.log.Infof("Context cancelled while waiting for ticker. Reason: %v. Exiting leader loop.", ctx.Err())
+				return
+			}
+			l.log.Debug("Ticker event: attempting election or renewal.")
+			attemptCtx, attemptCancel := context.WithTimeout(ctx, l.leaderElectionInterval-time.Millisecond*100) // Give some buffer
+			l.attemptElectionOrRenewal(attemptCtx)
+			attemptCancel()
+		}
+	}
+}
+
+// attemptElectionOrRenewal tries to become leader or renews the leadership if already leader.
+func (l *LeaderElector) attemptElectionOrRenewal(ctx context.Context) {
+	leaderKey := l.getLeaderKey()
+	l.log.Debugf("Attempting election/renewal for leader key: %s", leaderKey)
+
+	currentLeaderID, err := l.store.GetLockOwner(ctx, leaderKey)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			l.log.Warnf("Context error while getting lock owner for key '%s': %v", leaderKey, ctx.Err())
+			return // Context error, don't proceed
+		}
+		// Assume "key not found" if error is not context related.
+		// Specific error handling for "not found" should be preferred if Store provides it.
+		l.log.Warnf("Failed to get current leader for key '%s': %v. Assuming no leader or key expired.", leaderKey, err)
+		currentLeaderID = "" // Treat error as no current leader for safety, attempt to acquire.
+	}
+	l.log.Debugf("Current lock owner for key '%s' is '%s'. This instance is '%s'.", leaderKey, currentLeaderID, l.instanceID)
+
+
+	l.mu.Lock()
+	isCurrentlyLeader := l.isLeader
+	l.mu.Unlock()
+
+	if isCurrentlyLeader {
+		if currentLeaderID == l.instanceID {
+			l.log.Debugf("Instance is leader, renewing lock for key '%s'", leaderKey)
+			renewed, renewErr := l.store.RenewLock(ctx, leaderKey, l.instanceID, l.leaderLockExpiry)
+			if renewErr != nil {
+				if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					l.log.Warnf("Context error during lock renewal for key '%s': %v", leaderKey, ctx.Err())
+					// Don't change leader status based on context error during renewal, might recover.
+					return
+				}
+				l.log.Errorf("Failed to renew leadership lock for key '%s': %v. Stepping down.", leaderKey, renewErr)
+				l.setLeader(false, "renewal_failed_error")
+			} else if !renewed {
+				l.log.Warnf("Leadership renewal for key '%s' was not successful (e.g. lock lost or not granted by store). Stepping down.", leaderKey)
+				l.setLeader(false, "renewal_not_granted_by_store")
+			} else {
+				l.log.Debugf("Leadership renewed for instance on key '%s'", leaderKey)
+			}
+		} else {
+			l.log.Warnf("Instance thought it was leader, but current lock owner for key '%s' is '%s'. Stepping down.", leaderKey, currentLeaderID)
+			l.setLeader(false, "lock_usurped_or_expired_unexpectedly")
+		}
+	} else { // Not currently leader
+		if currentLeaderID == "" {
+			l.log.Infof("No active leader detected for key '%s'. Instance attempting to become leader.", leaderKey)
+			l.tryToBecomeLeader(ctx, leaderKey)
+		} else if currentLeaderID == l.instanceID {
+			// We are listed as leader in store, but don't know it locally (e.g. post-restart).
+			// Try to take ownership definitively.
+			l.log.Warnf("Instance is listed as leader in store for key '%s', but was not aware. Attempting to confirm and take leadership.", leaderKey)
+			l.tryToBecomeLeader(ctx, leaderKey) 
+		} else {
+			l.log.Debugf("Instance '%s' is current leader for key '%s'. This instance ('%s') is a follower.", currentLeaderID, leaderKey, l.instanceID)
+		}
+	}
+}
+
+// tryToBecomeLeader attempts to acquire the leader lock.
+func (l *LeaderElector) tryToBecomeLeader(ctx context.Context, leaderKey string) {
+	l.log.Infof("Instance attempting to acquire leadership for key '%s'...", leaderKey)
+	acquired, err := l.store.AcquireLock(ctx, leaderKey, l.instanceID, l.leaderLockExpiry)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			l.log.Warnf("Context cancelled or deadline exceeded while trying to acquire leadership for key '%s': %v", leaderKey, ctx.Err())
+		} else {
+			l.log.Errorf("Error trying to acquire leadership for key '%s': %v", leaderKey, err)
+		}
+		return
+	}
+
+	if acquired {
+		l.log.Infof("Instance successfully acquired leadership for key '%s'.", leaderKey)
+		l.setLeader(true, "acquired_new_lock_successfully")
+	} else {
+		l.log.Debugf("Instance failed to acquire leadership for key '%s' (already locked or SetNX failed).", leaderKey)
+		if l.IsLeader() { 
+			l.log.Warnf("Attempted to acquire lock for %s but failed, yet instance thought it was leader. Correcting.", leaderKey)
+		}
+		l.setLeader(false, "acquire_lock_denied_by_store")
+	}
+}
+
+// releaseLeadership releases the lock if this instance is the leader.
+func (l *LeaderElector) releaseLeadership(ctx context.Context, reason string) {
+	l.mu.Lock()
+	if !l.isLeader {
+		l.mu.Unlock()
+		l.log.Debugf("Instance is not leader, no need to release leadership (reason: %s).", reason)
+		return
+	}
+	l.isLeader = false
+	l.mu.Unlock() 
+
+	leaderKey := l.getLeaderKey()
+	l.log.Infof("Instance, which believed it was leader, attempting to release leadership for key '%s' (reason: %s).", leaderKey, reason)
+
+	checkCtx, checkCancel := context.WithTimeout(ctx, l.leaderElectionInterval/2)
+	defer checkCancel()
+	currentOwner, err := l.store.GetLockOwner(checkCtx, leaderKey)
+	if err != nil {
+		l.log.Warnf("Failed to get lock owner for key '%s' during release: %v. Proceeding with release attempt cautiously.", leaderKey, err)
+	} else if currentOwner != "" && currentOwner != l.instanceID {
+		l.log.Warnf("Instance attempted to release lock for key '%s', but owner is '%s'. Not releasing.", leaderKey, currentOwner)
+		return
+	}
+
+	releaseOpCtx, releaseOpCancel := context.WithTimeout(ctx, l.leaderElectionInterval/2)
+	defer releaseOpCancel()
+	err = l.store.ReleaseLock(releaseOpCtx, leaderKey, l.instanceID)
+	if err != nil {
+		l.log.Errorf("Failed to release leadership lock for key '%s': %v", leaderKey, err)
+	} else {
+		l.log.Infof("Leadership lock for key '%s' released by instance.", leaderKey)
+	}
+}
+
+// IsLeader returns true if this instance is currently the leader.
+func (l *LeaderElector) IsLeader() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.isLeader
+}
+
+// setLeader updates the leadership status and logs changes.
+func (l *LeaderElector) setLeader(isLeader bool, reason string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.isLeader == isLeader {
+		return // No change
+	}
+	l.isLeader = isLeader
+
+	if isLeader {
+		l.log.Infof("IS NOW LEADER. Reason: %s", reason)
+	} else {
+		l.log.Infof("IS NO LONGER LEADER. Reason: %s", reason)
+	}
+}
+
+// Stop gracefully stops the leader election loop and releases leadership if held.
+func (l *LeaderElector) Stop() {
+	l.log.Infof("Stopping leader elector for namespace %s...", l.namespace)
+	l.mu.Lock()
+	if l.cancelLeader != nil {
+		l.cancelLeader()
+		l.cancelLeader = nil 
+	}
+	wasLeader := l.isLeader 
+	l.mu.Unlock()
+
+
+	if wasLeader {
+		releaseCtx, cancelRelease := context.WithTimeout(context.Background(), l.leaderLockExpiry/2+time.Millisecond*200) 
+		defer cancelRelease()
+		l.log.Debugf("Calling releaseLeadership from Stop() because wasLeader=true.")
+		l.releaseLeadership(releaseCtx, "elector_stopped")
+	} else {
+		l.log.Debugf("Stop() called, wasLeader=false, no proactive release needed.")
+	}
+	l.log.Infof("Leader elector for namespace %s has been signaled to stop.", l.namespace)
+}

--- a/mgr.go
+++ b/mgr.go
@@ -2,13 +2,20 @@ package elk_coordinator
 
 import (
 	"context"
+	"context"
 	"elk_coordinator/data"
 	"fmt"
+	"os"
+	"os/signal" // For signal handling
+	"strings"  // Added for strings.TrimPrefix
+	"sync"
+	"syscall" // For signal handling
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"os"
-	"sync"
-	"time"
+	"github.com/sirupsen/logrus" // For logger interaction with LeaderElector
+	"golang.org/x/sync/errgroup"
 )
 
 // Mgr 是一个分布式管理器，管理分区任务的执行
@@ -16,11 +23,17 @@ type Mgr struct {
 	// 核心字段
 	ID            string
 	Namespace     string
-	DataStore     data.DataStore
+	DataStore     data.DataStore // Must implement leader_election.Store
 	TaskProcessor Processor
 	Logger        Logger
 
-	// 配置选项
+	// Leader Elector
+	leaderElector *LeaderElector // Instance of the new LeaderElector
+	// Node Manager
+	nodeManager *NodeManager // Instance of the new NodeManager
+
+	// 配置选项 (LeaderElectionInterval and LeaderLockExpiry are used to configure LeaderElector)
+	// HeartbeatInterval is used to configure NodeManager
 	HeartbeatInterval       time.Duration // 心跳间隔
 	LeaderElectionInterval  time.Duration // Leader选举间隔
 	PartitionLockExpiry     time.Duration // 分区锁过期时间
@@ -39,41 +52,40 @@ type Mgr struct {
 	Metrics                 *WorkerMetrics // 节点性能指标
 	metricsMutex            sync.RWMutex   // 指标访问互斥锁
 
+	// Stale Task Reclaiming
+	StaleTaskReclaimMultiplier float64 // Multiplier for PartitionLockExpiry to determine stale task threshold
+
 	// 内部状态
-	isLeader        bool
-	heartbeatCtx    context.Context
-	cancelHeartbeat context.CancelFunc
-	leaderCtx       context.Context
-	cancelLeader    context.CancelFunc
+	// heartbeatCtx and cancelHeartbeat are now in NodeManager
 	workCtx         context.Context
 	cancelWork      context.CancelFunc
-	mu              sync.RWMutex
+	mu              sync.RWMutex // Protects Mgr's mutable state
+
+	stopOnce sync.Once     // Ensures Stop() logic runs only once
+	stopCh   chan struct{} // Signals shutdown completion
 }
 
 // NewMgr 创建一个新的管理器实例，使用选项模式配置可选参数
 func NewMgr(namespace string, dataStore data.DataStore, processor Processor, options ...MgrOption) *Mgr {
 	nodeID := generateNodeID()
 
-	// 创建带默认值的管理器
+	// Create Mgr with default values
 	mgr := &Mgr{
 		ID:            nodeID,
 		Namespace:     namespace,
 		DataStore:     dataStore,
 		TaskProcessor: processor,
-		Logger:        &defaultLogger{},
+		Logger:        NewDefaultLogger(), // Use constructor for defaultLogger
 
-		// 默认配置
+		// Default configurations
 		HeartbeatInterval:       DefaultHeartbeatInterval,
 		LeaderElectionInterval:  DefaultLeaderElectionInterval,
 		PartitionLockExpiry:     DefaultPartitionLockExpiry,
 		LeaderLockExpiry:        DefaultLeaderLockExpiry,
 		WorkerPartitionMultiple: DefaultWorkerPartitionMultiple,
-
-		// 任务窗口默认配置
-		UseTaskWindow:  false,
-		TaskWindowSize: DefaultTaskWindowSize,
-
-		// 指标收集默认配置
+		StaleTaskReclaimMultiplier: DefaultStaleTaskReclaimMultiplier, // Initialize with default
+		UseTaskWindow:           false,
+		TaskWindowSize:          DefaultTaskWindowSize,
 		UseTaskMetrics:          true,
 		MetricsUpdateInterval:   DefaultCapacityUpdateInterval,
 		RecentPartitionsToTrack: DefaultRecentPartitions,
@@ -86,12 +98,74 @@ func NewMgr(namespace string, dataStore data.DataStore, processor Processor, opt
 			TotalItemsProcessed: 0,
 			LastUpdateTime:      time.Now(),
 		},
+		stopCh: make(chan struct{}),
 	}
 
-	// 应用所有选项
+	// Apply all options. Options might override Logger, LeaderElectionInterval, LeaderLockExpiry, etc.
 	for _, option := range options {
 		option(mgr)
 	}
+
+	// Extract logrus.Entry from mgr.Logger for LeaderElector
+	// This part needs to be robust. Assuming Logger has a way to get a logrus.Entry
+	// or NewLeaderElector can handle a generic logger or has a fallback.
+	var leLogEntry *logrus.Entry
+	// Attempt to get a logrus entry from the logger.
+	// This is a placeholder for actual mechanism.
+	// If your Logger is always a wrapper around logrus, you can cast it.
+	// For example: if loggerWrapper, ok := mgr.Logger.(interface{ GetLogrusEntry() *logrus.Entry }); ok {
+	// 	leLogEntry = loggerWrapper.GetLogrusEntry()
+	// } else {
+	// Fallback if the logger doesn't provide a logrus.Entry
+	// Create a new one, but this means LeaderElector logs might be separate.
+	// mgr.Logger.Warnf("Could not extract logrus.Entry for LeaderElector, using a default one.")
+	// tempLogger := logrus.New()
+	// tempLogger.SetFormatter(mgr.Logger.(*defaultLogger).entry.Logger.Formatter) // try to use similar formatter
+	// leLogEntry = logrus.NewEntry(tempLogger)
+	// }
+	// For now, let's assume defaultLogger can provide its entry or NewLeaderElector handles it.
+	// Consolidated logic for deriving *logrus.Entry for sub-components (LeaderElector, NodeManager)
+	var subsystemLogEntry *logrus.Entry
+	if defaultLog, ok := mgr.Logger.(*defaultLogger); ok {
+		// If mgr.Logger is the defaultLogger, use its internal logrus entry.
+		// NewLeaderElector and NewNodeManager will further customize this with WithField.
+		subsystemLogEntry = defaultLog.entry
+	} else {
+		// If mgr.Logger is a custom type (set via WithLogger), create a new default logrus entry for sub-components.
+		mgr.Logger.Warnf("Mgr.Logger is a custom implementation and not a *defaultLogger. LeaderElector and NodeManager will use a separate, default logrus logger.")
+		fallbackLog := logrus.New()
+		// Attempt to match the level of the custom logger if possible, otherwise default to Info.
+		// This requires the custom Logger interface to expose a GetLevel() or similar,
+		// or we just default it. For now, defaulting to InfoLevel.
+		// if customLoggerWithLevel, ok := mgr.Logger.(interface{ GetLevel() logrus.Level }); ok {
+		// 	fallbackLog.SetLevel(customLoggerWithLevel.GetLevel())
+		// } else {
+		fallbackLog.SetLevel(logrus.InfoLevel)
+		// }
+		fallbackLog.SetFormatter(&logrus.TextFormatter{FullTimestamp: true, TimestampFormat: "2006-01-02T15:04:05.000Z07:00"}) // Consistent formatting
+		subsystemLogEntry = logrus.NewEntry(fallbackLog)
+	}
+
+	// Initialize LeaderElector
+	mgr.leaderElector = NewLeaderElector(
+		mgr.ID,
+		mgr.Namespace,
+		mgr.DataStore,
+		subsystemLogEntry, // Pass the derived logrus.Entry
+		mgr.LeaderLockExpiry,
+		mgr.LeaderElectionInterval,
+		// No longer pass keyFmt here, LeaderElector will use the global constant
+	)
+
+	// Initialize NodeManager
+	mgr.nodeManager = NewNodeManager(
+		mgr.ID,
+		mgr.Namespace,
+		mgr.DataStore,     // Pass the full DataStore
+		subsystemLogEntry, // Pass the same derived logrus.Entry
+		mgr.HeartbeatInterval,
+		// No longer pass keyFmt here, NodeManager will use the global constants
+	)
 
 	return mgr
 }
@@ -117,94 +191,87 @@ func generateNodeID() string {
 func (m *Mgr) Start(ctx context.Context) error {
 	m.Logger.Infof("启动管理器 %s, 命名空间: %s", m.ID, m.Namespace)
 
-	// 创建上下文
-	m.heartbeatCtx, m.cancelHeartbeat = context.WithCancel(context.Background())
-	m.workCtx, m.cancelWork = context.WithCancel(context.Background())
+	m.Logger.Infof("启动管理器 %s, 命名空间: %s", m.ID, m.Namespace)
+	var g *errgroup.Group
+	gCtx, gCancel := context.WithCancel(ctx) 
+	g, gCtx = errgroup.WithContext(gCtx)
+	m.mu.Lock()
+	m.workCtx, m.cancelWork = context.WithCancel(gCtx) 
+	// m.heartbeatCtx and m.cancelHeartbeat are now managed by NodeManager
+	m.mu.Unlock()
 
-	// 注册本节点，并周期发送心跳
-	go m.nodeKeeper(ctx)
 
-	// 做leader相关的工作
-	go m.Lead(ctx)
+	// Goroutine for leader election
+	m.leaderElector.Lead(gCtx, g)
 
-	// 处理分配任务
-	go m.Handle(ctx)
-
-	// 设置信号处理，捕获终止信号
-	go m.setupSignalHandler(ctx)
-
-	// 如果启用了指标收集，定期发布指标
-	if m.UseTaskMetrics {
-		go m.publishMetricsPeriodically(ctx)
-	}
-
-	return nil
-}
-
-// IsLeader 返回当前节点是否是Leader
-func (m *Mgr) IsLeader() bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.isLeader
-}
-
-// nodeKeeper 管理节点注册和心跳
-func (m *Mgr) nodeKeeper(ctx context.Context) {
-	m.Logger.Infof("开始节点维护任务")
-
-	// 注册本节点
-	err := m.registerNode(ctx)
-	if err != nil {
-		m.Logger.Errorf("注册节点失败: %v", err)
-		return
-	}
-
-	// 周期性发送心跳
-	ticker := time.NewTicker(m.HeartbeatInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			m.Logger.Infof("节点维护任务停止 (上下文取消)")
-			return
-		case <-m.heartbeatCtx.Done():
-			m.Logger.Infof("节点维护任务停止 (心跳上下文取消)")
-			return
-		case <-ticker.C:
-			heartbeatKey := fmt.Sprintf(HeartbeatFmtFmt, m.Namespace, m.ID)
-			err := m.DataStore.SetHeartbeat(ctx, heartbeatKey, time.Now().Format(time.RFC3339))
-			if err != nil {
-				m.Logger.Warnf("发送心跳失败: %v", err)
-			}
+	// Goroutine for node registration and heartbeats (managed by NodeManager)
+	g.Go(func() error {
+		// NodeManager.Start will run its own loop in a goroutine if needed by its design.
+		// Or, if NodeManager.Start is blocking, this g.Go call is appropriate.
+		// Based on the NodeManager skeleton, its Start calls registerNode then go nm.nodeKeeperLoop.
+		// So, NodeManager.Start itself is not blocking in the long run.
+		err := m.nodeManager.Start(gCtx)
+		if err != nil {
+			m.Logger.Errorf("NodeManager failed to start: %v", err)
+			// To ensure the error group cancels other goroutines if NodeManager fails critically on start:
+			// return err (this depends on how critical an initial NodeManager start failure is)
 		}
+		// If NodeManager.Start is non-blocking and its internal goroutine (nodeKeeperLoop) needs to be waited for,
+		// NodeManager.Start should return a channel or an error to signal its goroutine's termination.
+		// For now, assume NodeManager.Start correctly uses gCtx for its long-running tasks.
+		// We need to ensure nodeManager.nodeKeeperLoop respects gCtx.
+		// The current node_manager.go does this.
+		<-gCtx.Done() // Wait for group context to be done to keep this goroutine alive if Start is non-blocking
+		m.Logger.Infof("NodeManager's context (gCtx) is done in Mgr.Start: %v", gCtx.Err())
+		return nil 
+	})
+
+	// Goroutine for task handling
+	g.Go(func() error {
+		m.Handle(m.workCtx) // Use workCtx
+		return nil
+	})
+
+	// Goroutine for signal handling
+	g.Go(func() error {
+		m.setupSignalHandler(gCtx, gCancel) // Pass group context and its cancel func
+		return nil
+	})
+
+	// Goroutine for metrics publishing
+	if m.UseTaskMetrics {
+		g.Go(func() error {
+			m.publishMetricsPeriodically(gCtx) // Use group context
+			return nil
+		})
 	}
+
+	m.Logger.Infof("Manager %s started all components.", m.ID)
+
+	// Wait for all goroutines in the group to finish or for an error.
+	err := g.Wait()
+	if err != nil && !errors.Is(err, context.Canceled) {
+		m.Logger.Errorf("Manager %s encountered an error from a component: %v", m.ID, err)
+	}
+
+	m.Logger.Infof("Manager %s is shutting down.", m.ID)
+	m.Stop() // Ensure Stop logic is called to clean up other resources
+	close(m.stopCh) // Signal that shutdown is complete
+	return err
 }
 
-// registerNode 注册节点到系统
-func (m *Mgr) registerNode(ctx context.Context) error {
-	heartbeatKey := fmt.Sprintf(HeartbeatFmtFmt, m.Namespace, m.ID)
-	workersKey := fmt.Sprintf(WorkersKeyFmt, m.Namespace)
-
-	err := m.DataStore.RegisterWorker(
-		ctx,
-		workersKey,
-		m.ID,
-		heartbeatKey,
-		time.Now().Format(time.RFC3339),
-	)
-
-	if err != nil {
-		return errors.Wrap(err, "注册节点失败")
+// IsLeader returns true if this instance is currently the leader.
+func (m *Mgr) IsLeader() bool {
+	if m.leaderElector == nil {
+		m.Logger.Warnf("IsLeader called before leaderElector is initialized.")
+		return false
 	}
-
-	m.Logger.Infof("节点 %s 已注册", m.ID)
-	return nil
+	return m.leaderElector.IsLeader()
 }
 
 // getActiveWorkers 获取活跃节点列表
 func (m *Mgr) getActiveWorkers(ctx context.Context) ([]string, error) {
-	pattern := fmt.Sprintf(HeartbeatFmtFmt, m.Namespace, "*")
+	pattern := fmt.Sprintf(HeartbeatKeyFormat, m.Namespace, "*")
 	keys, err := m.DataStore.GetKeys(ctx, pattern)
 	if err != nil {
 		return nil, errors.Wrap(err, "获取心跳失败")
@@ -214,33 +281,75 @@ func (m *Mgr) getActiveWorkers(ctx context.Context) ([]string, error) {
 	now := time.Now()
 	validHeartbeatDuration := m.HeartbeatInterval * 3
 
-	for _, key := range keys {
-		// 从key中提取节点ID
-		prefix := fmt.Sprintf(HeartbeatFmtFmt, m.Namespace, "")
-		nodeID := key[len(prefix):]
+	// Construct the prefix to trim based on HeartbeatKeyFormat
+	// Example: HeartbeatKeyFormat = "elk_coord/%s/heartbeats/%s"
+	// Prefix for namespace "my_ns" would be "elk_coord/my_ns/heartbeats/"
+	// This is achieved by formatting with an empty string for the nodeID part and then removing the trailing %s,
+	// or more simply by finding the last element after splitting.
+	// A more robust way is to replace the last '%s' with an empty string for prefix construction.
+	
+	// Assuming HeartbeatKeyFormat is "elk_coord/%s/heartbeats/%s"
+	// The part before the nodeID is "elk_coord/NAMESPACE/heartbeats/"
+	keyPrefixToTrim := fmt.Sprintf(HeartbeatKeyFormat, m.Namespace, "") 
+	// This results in "elk_coord/NAMESPACE/heartbeats/%s". We need to remove the final '%s'.
+	// A safer way if the format is fixed:
+	// keyPrefixToTrim = "elk_coord/" + m.Namespace + "/heartbeats/"
+	// Let's use strings.LastIndex to find the last part as nodeID for robustness with the format string.
+	// However, given the task asks for TrimPrefix, we'll construct the prefix carefully.
+	// If HeartbeatKeyFormat = "elk_coord/%s/heartbeats/%s",
+	// then fmt.Sprintf(HeartbeatKeyFormat, m.Namespace, "PLACEHOLDER_NODE_ID") gives "elk_coord/ns/heartbeats/PLACEHOLDER_NODE_ID"
+	// The prefix part is "elk_coord/ns/heartbeats/"
+	tempFormattedKeyForPrefix := fmt.Sprintf(HeartbeatKeyFormat, m.Namespace, "X") // X is a placeholder
+	prefixToTrim := tempFormattedKeyForPrefix[:strings.LastIndex(tempFormattedKeyForPrefix, "X")]
 
-		// 获取最后心跳时间
-		lastHeartbeatStr, err := m.DataStore.GetHeartbeat(ctx, key)
+
+	for _, key := range keys {
+		var nodeID string
+		if strings.HasPrefix(key, prefixToTrim) {
+			nodeID = strings.TrimPrefix(key, prefixToTrim)
+		} else {
+			// Fallback or log warning if key doesn't match expected prefix structure
+			// This might happen if GetKeys returns keys not matching the exact format
+			m.Logger.Warnf("getActiveWorkers: key '%s' does not match expected prefix '%s'. Extracting last segment as nodeID.", key, prefixToTrim)
+			parts := strings.Split(key, "/")
+			if len(parts) > 0 {
+				nodeID = parts[len(parts)-1]
+			} else {
+				m.Logger.Errorf("getActiveWorkers: Could not parse nodeID from key '%s'", key)
+				continue
+			}
+		}
+		
+		if nodeID == "" {
+			m.Logger.Warnf("getActiveWorkers: extracted empty nodeID from key '%s' with prefix '%s'", key, prefixToTrim)
+			continue
+		}
+
+		lastHeartbeatStr, err := m.DataStore.GetHeartbeat(ctx, key) // Use full key to get heartbeat
 		if err != nil {
-			continue // 跳过错误的心跳
+			m.Logger.Warnf("getActiveWorkers: failed to get heartbeat for key %s: %v", key, err)
+			continue 
 		}
 
 		lastHeartbeat, err := time.Parse(time.RFC3339, lastHeartbeatStr)
 		if err != nil {
-			continue // 跳过无效的时间格式
+			m.Logger.Warnf("getActiveWorkers: failed to parse heartbeat time for key %s ('%s'): %v", key, lastHeartbeatStr, err)
+			continue 
 		}
 
-		// 检查心跳是否有效
 		if now.Sub(lastHeartbeat) <= validHeartbeatDuration {
 			activeWorkers = append(activeWorkers, nodeID)
 		} else {
-			// 删除过期心跳
-			m.DataStore.DeleteKey(ctx, key)
+			m.Logger.Infof("getActiveWorkers: Stale heartbeat for nodeID %s (key %s). Last updated: %v. Deleting key.", nodeID, key, lastHeartbeat)
+			if delErr := m.DataStore.DeleteKey(ctx, key); delErr != nil { // Use full key to delete
+				m.Logger.Warnf("getActiveWorkers: Failed to delete stale heartbeat key %s: %v", key, delErr)
+			}
 		}
 	}
 
 	return activeWorkers, nil
 }
+
 
 // SetWorkerPartitionMultiple 已被选项模式替代，保留用于向后兼容
 //
@@ -254,3 +363,182 @@ func (m *Mgr) SetWorkerPartitionMultiple(multiple int64) {
 	}
 	m.WorkerPartitionMultiple = multiple
 }
+
+// Stop gracefully shuts down the manager and its components.
+// It's idempotent and can be called multiple times.
+func (m *Mgr) Stop() {
+	m.stopOnce.Do(func() {
+		m.Logger.Infof("Manager %s received stop signal.", m.ID)
+
+		// Stop LeaderElector first
+		if m.leaderElector != nil {
+			m.Logger.Debugf("Stopping leader elector for %s.", m.ID)
+			m.leaderElector.Stop() // LeaderElector.Stop should be idempotent and handle its own context/cleanup.
+			m.Logger.Debugf("Leader elector for %s signaled to stop.", m.ID)
+		}
+
+		// Stop NodeManager
+		if m.nodeManager != nil {
+			m.Logger.Debugf("Stopping node manager for %s.", m.ID)
+			// NodeManager.Stop should also be idempotent and handle its cleanup.
+			// It might need its own context for cleanup operations.
+			stopCtx, cancelStopCtx := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelStopCtx()
+			if err := m.nodeManager.Stop(stopCtx); err != nil {
+				m.Logger.Warnf("Error stopping node manager for %s: %v", m.ID, err)
+			}
+			m.Logger.Debugf("Node manager for %s signaled to stop.", m.ID)
+		}
+
+		// Cancel main work context controlled by Mgr (if not already cancelled by errgroup)
+		m.mu.Lock()
+		// cancelHeartbeat is now managed by NodeManager
+		if m.cancelWork != nil {
+			m.Logger.Debugf("Cancelling work context for %s.", m.ID)
+			m.cancelWork()
+			m.cancelWork = nil
+		}
+		m.mu.Unlock()
+		
+		// Note: The unregisterNode logic is now part of NodeManager.Stop().
+		// If there was a global errgroup context cancel function (gCancel in Start),
+		// it should ideally be called here or by setupSignalHandler to ensure all errgroup goroutines are stopped.
+		// However, calling it here might be redundant if Stop is called from Start's defer/error handling.
+
+		m.Logger.Infof("Manager %s shutdown process initiated/completed.", m.ID)
+	})
+}
+
+// WaitUntilStopped blocks until the manager has fully shut down.
+func (m *Mgr) WaitUntilStopped() {
+	<-m.stopCh
+	m.Logger.Infof("Manager %s has confirmed full stop.", m.ID)
+}
+
+
+// setupSignalHandler listens for termination signals and initiates a graceful shutdown.
+// It now also accepts the errgroup's main context cancel function.
+func (m *Mgr) setupSignalHandler(ctx context.Context, cancelGroup context.CancelFunc) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	m.Logger.Debug("Signal handler started.")
+
+	select {
+	case sig := <-sigCh:
+		m.Logger.Infof("Received signal: %s. Initiating graceful shutdown...", sig)
+		cancelGroup() // Cancel the main errgroup context, which will propagate to components
+		m.Stop()      // Call Mgr's Stop method for further cleanup
+	case <-ctx.Done(): // Listen for context cancellation from other sources (e.g. errgroup itself)
+		m.Logger.Infof("Signal handler context done: %v. Shutting down...", ctx.Err())
+		// If ctx.Done() is triggered, it means the errgroup is already stopping.
+		// Stop() might have already been called or will be by Start()'s defer.
+		// Calling it again is fine due to stopOnce.
+		m.Stop()
+	}
+	m.Logger.Debug("Signal handler finished.")
+}
+
+// DefaultLogger returns a new default logger instance.
+// This needs to be defined if it's not in a separate logger.go file.
+// For now, to make this file self-contained for the diff.
+type defaultLogger struct {
+	entry *logrus.Entry
+}
+
+func NewDefaultLogger() Logger {
+	l := logrus.New()
+	l.SetFormatter(&logrus.TextFormatter{FullTimestamp: true, TimestampFormat: "2006-01-02T15:04:05.000Z07:00"})
+	l.SetLevel(logrus.InfoLevel)
+	return &defaultLogger{entry: logrus.NewEntry(l)}
+}
+
+func (l *defaultLogger) WithField(key string, value interface{}) Logger {
+	return &defaultLogger{entry: l.entry.WithField(key, value)}
+}
+
+func (l *defaultLogger) WithFields(fields map[string]interface{}) Logger {
+	//logrus.Fields is map[string]interface{}
+	return &defaultLogger{entry: l.entry.WithFields(logrus.Fields(fields))}
+}
+func (l *defaultLogger) Debugf(format string, args ...interface{}) { l.entry.Debugf(format, args...) }
+func (l *defaultLogger) Infof(format string, args ...interface{})  { l.entry.Infof(format, args...) }
+func (l *defaultLogger) Warnf(format string, args ...interface{})  { l.entry.Warnf(format, args...) }
+func (l *defaultLogger) Errorf(format string, args ...interface{}) { l.entry.Errorf(format, args...) }
+func (l *defaultLogger) Fatalf(format string, args ...interface{}) { l.entry.Fatalf(format, args...) }
+func (l *defaultLogger) Panicf(format string, args ...interface{}) { l.entry.Panicf(format, args...) }
+
+// Ensure defaultLogger implements Logger
+var _ Logger = (*defaultLogger)(nil)
+
+
+// TODO: Remove this if it exists in mgr.go already and was just not in the initial snippet.
+// These constants are assumed to be defined elsewhere, adding them here for compilation if not.
+// (HeartbeatFmtFmt and WorkersKeyFmt are removed as they are now centralized)
+const (
+	DefaultHeartbeatInterval      = 10 * time.Second
+	DefaultLeaderElectionInterval = 15 * time.Second
+	DefaultPartitionLockExpiry    = 60 * time.Second
+	DefaultLeaderLockExpiry       = 30 * time.Second
+	DefaultWorkerPartitionMultiple = 3
+	DefaultTaskWindowSize         = 10
+	DefaultCapacityUpdateInterval = 30 * time.Second
+	DefaultRecentPartitions       = 100
+	DefaultStaleTaskReclaimMultiplier = 3.0 // Default value for stale task reclaim multiplier
+	// HeartbeatFmtFmt               = "elk_coord/%s/heartbeats/%s" // Moved to constants/keys.go
+	// WorkersKeyFmt                 = "elk_coord/%s/workers"       // Moved to constants/keys.go
+)
+
+// TODO: Remove this if Processor interface is defined elsewhere.
+type Processor interface {
+	Process(ctx context.Context, partitionID string) error
+	// other methods...
+}
+
+// TODO: Remove this if TaskWindow is defined elsewhere.
+type TaskWindow struct {
+	// fields...
+}
+
+// TODO: Remove this if WorkerMetrics is defined elsewhere.
+type WorkerMetrics struct {
+	ProcessingSpeed     float64
+	SuccessRate         float64
+	AvgProcessingTime   time.Duration
+	TotalTasksCompleted int64
+	SuccessfulTasks     int64
+	TotalItemsProcessed int64
+	LastUpdateTime      time.Time
+}
+
+// TODO: Remove this if Handle, publishMetricsPeriodically are complex and defined elsewhere.
+// Adding stubs for compilation.
+func (m *Mgr) Handle(ctx context.Context) {
+	m.Logger.Infof("Task handling loop started for %s. Waiting for assignments or context cancellation.", m.ID)
+	<-ctx.Done() // Simulate work until context is cancelled
+	m.Logger.Infof("Task handling loop for %s stopped: %v", m.ID, ctx.Err())
+}
+
+func (m *Mgr) publishMetricsPeriodically(ctx context.Context) {
+	m.Logger.Infof("Metrics publishing loop started for %s.", m.ID)
+	ticker := time.NewTicker(m.MetricsUpdateInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			m.Logger.Infof("Metrics publishing loop for %s stopped: %v", m.ID, ctx.Err())
+			return
+		case <-ticker.C:
+			if ctx.Err() != nil {
+				m.Logger.Infof("Metrics publishing loop for %s stopping due to context error: %v", m.ID, ctx.Err())
+				return
+			}
+			m.Logger.Debugf("Publishing metrics for %s.", m.ID)
+			// Actual metrics publishing logic here
+		}
+	}
+}
+
+// Removed splitKey helper as it was a placeholder and not used.
+// func splitKey(key, sep string) []string {
+//     return nil 
+// }

--- a/node_manager.go
+++ b/node_manager.go
@@ -1,0 +1,179 @@
+package elk_coordinator
+
+import (
+	"context"
+	"elk_coordinator/data" // Import data package
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// NodeManager handles node registration and heartbeats.
+type NodeManager struct {
+	instanceID string
+	namespace  string
+	store      data.DataStore // Changed from Store to data.DataStore
+	log        *logrus.Entry
+
+	heartbeatInterval time.Duration
+	heartbeatCtx      context.Context
+	cancelHeartbeat   context.CancelFunc
+}
+
+// NewNodeManager creates a new NodeManager.
+// The store parameter is now data.DataStore.
+func NewNodeManager(
+	instanceID string,
+	namespace string,
+	store data.DataStore, // Changed from Store to data.DataStore
+	log *logrus.Entry,
+	heartbeatInterval time.Duration,
+) *NodeManager {
+	actualLog := log
+	if actualLog == nil {
+		actualLog = logrus.NewEntry(logrus.New())
+		actualLog.Warn("NewNodeManager received a nil logger, using a default one.")
+	}
+
+	return &NodeManager{
+		instanceID:        instanceID,
+		namespace:         namespace,
+		store:             store,
+		log:               actualLog.WithField("component", "node-manager").WithField("instance_id", instanceID),
+		heartbeatInterval: heartbeatInterval,
+	}
+}
+
+// Start begins the node keeping process (registration and periodic heartbeats).
+func (nm *NodeManager) Start(ctx context.Context) error {
+	nm.log.Infof("Node manager starting for instance %s in namespace '%s'", nm.instanceID, nm.namespace)
+	nm.heartbeatCtx, nm.cancelHeartbeat = context.WithCancel(ctx)
+
+	// Register the node first.
+	err := nm.registerNode(nm.heartbeatCtx)
+	if err != nil {
+		nm.log.Errorf("Failed to register node %s: %v", nm.instanceID, err)
+		return errors.Wrap(err, "node registration failed during start")
+	}
+
+	// Start the heartbeat loop.
+	go nm.nodeKeeperLoop(nm.heartbeatCtx)
+
+	return nil
+}
+
+// Stop terminates the node keeping process.
+func (nm *NodeManager) Stop(ctx context.Context) error {
+	nm.log.Infof("Node manager stopping for instance %s...", nm.instanceID)
+	if nm.cancelHeartbeat != nil {
+		nm.cancelHeartbeat()
+	}
+
+	err := nm.unregisterNode(ctx)
+	if err != nil {
+		nm.log.Warnf("Failed to unregister node %s during stop: %v", nm.instanceID, err)
+	} else {
+		nm.log.Infof("Node %s unregistered successfully.", nm.instanceID)
+	}
+
+	nm.log.Infof("Node manager for instance %s stopped.", nm.instanceID)
+	return nil // Return nil or the error from unregisterNode as appropriate
+}
+
+// nodeKeeperLoop manages periodic heartbeats.
+func (nm *NodeManager) nodeKeeperLoop(ctx context.Context) {
+	defer nm.log.Infof("Node keeper loop stopped for instance %s.", nm.instanceID)
+	ticker := time.NewTicker(nm.heartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			nm.log.Infof("Node keeper loop for instance %s received stop signal: %v", nm.instanceID, ctx.Err())
+			return
+		case <-ticker.C:
+			if ctx.Err() != nil {
+				nm.log.Infof("Context cancelled before sending heartbeat for %s. Exiting loop.", nm.instanceID)
+				return
+			}
+			heartbeatKey := fmt.Sprintf(HeartbeatKeyFormat, nm.namespace, nm.instanceID)
+			hbCtx, hbCancel := context.WithTimeout(ctx, nm.heartbeatInterval/2)
+			
+			// Removed type assertion, calling SetHeartbeat directly on nm.store
+			err := nm.store.SetHeartbeat(hbCtx, heartbeatKey, time.Now().Format(time.RFC3339))
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					nm.log.Warnf("Sending heartbeat timed out for key %s: %v", heartbeatKey, err)
+				} else if errors.Is(err, context.Canceled) {
+					nm.log.Infof("Context cancelled, stopping heartbeat for key %s: %v", heartbeatKey, err)
+					hbCancel()
+					return
+				} else {
+					nm.log.Warnf("Failed to send heartbeat for key %s: %v", heartbeatKey, err)
+				}
+			} else {
+				nm.log.Debugf("Heartbeat sent for %s", nm.instanceID)
+			}
+			hbCancel()
+		}
+	}
+}
+
+// registerNode registers this instance with the data store.
+func (nm *NodeManager) registerNode(ctx context.Context) error {
+	nm.log.Infof("Registering node %s...", nm.instanceID)
+	heartbeatKey := fmt.Sprintf(HeartbeatKeyFormat, nm.namespace, nm.instanceID)
+	workersKey := fmt.Sprintf(WorkersKeyFormat, nm.namespace)
+
+	regCtx, regCancel := context.WithTimeout(ctx, nm.heartbeatInterval)
+	defer regCancel()
+
+	// Removed type assertion, calling RegisterWorker directly on nm.store
+	err := nm.store.RegisterWorker(
+		regCtx,
+		workersKey,
+		nm.instanceID,
+		heartbeatKey,
+		time.Now().Format(time.RFC3339),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to register worker with store")
+	}
+
+	nm.log.Infof("Node %s registered successfully.", nm.instanceID)
+	return nil
+}
+
+// unregisterNode removes this instance's registration from the data store.
+func (nm *NodeManager) unregisterNode(ctx context.Context) error {
+	nm.log.Infof("Unregistering node %s...", nm.instanceID)
+	heartbeatKey := fmt.Sprintf(HeartbeatKeyFormat, nm.namespace, nm.instanceID)
+	// The UnregisterWorker method from data.DataStore might be more appropriate if it exists and handles all necessary cleanup.
+	// For now, using DeleteKey for the heartbeatKey as per previous logic.
+	// If workersKey also needs cleanup, that would be an additional step or part of a dedicated UnregisterWorker.
+	// The current data.DataStore interface has UnregisterWorker(ctx, workersKey, workerID, heartbeatKey).
+	// Let's use that for a more complete unregistration.
+
+	workersKey := fmt.Sprintf(WorkersKeyFormat, nm.namespace)
+
+	unregCtx, unregCancel := context.WithTimeout(ctx, nm.heartbeatInterval)
+	defer unregCancel()
+
+	// Using the UnregisterWorker method from data.DataStore
+	err := nm.store.UnregisterWorker(unregCtx, workersKey, nm.instanceID, heartbeatKey)
+	if err != nil {
+		// If UnregisterWorker fails, log it. Depending on the error, one might still want to attempt
+		// to delete the heartbeat key directly as a fallback, but that could lead to partial states.
+		// For now, we just return the error from UnregisterWorker.
+		return errors.Wrapf(err, "failed to unregister worker %s (heartbeat key: %s, workers key: %s)", nm.instanceID, heartbeatKey, workersKey)
+	}
+	
+	// Previously, it was just deleting the heartbeatKey.
+	// err := nm.store.DeleteKey(unregCtx, heartbeatKey)
+	// if err != nil {
+	// 	return errors.Wrapf(err, "failed to delete heartbeat key %s during unregistration", heartbeatKey)
+	// }
+	return nil
+}

--- a/options.go
+++ b/options.go
@@ -119,3 +119,19 @@ func WithRecentPartitionsTracking(count int) MgrOption {
 		m.RecentPartitionsToTrack = count
 	}
 }
+
+// WithStaleTaskReclaimMultiplier sets the multiplier for PartitionLockExpiry to determine when a task is considered stale.
+// A stale task (Claimed or Running but not updated for StaleTaskReclaimMultiplier * PartitionLockExpiry)
+// can be reclaimed by another worker. The default multiplier is DefaultStaleTaskReclaimMultiplier (e.g., 3.0).
+func WithStaleTaskReclaimMultiplier(multiplier float64) MgrOption {
+	return func(m *Mgr) {
+		if multiplier <= 0 {
+			// Logger might not be initialized yet if this option is set before WithLogger.
+			// So, we can't use m.Logger here reliably without checking for nil.
+			// For simplicity, we'll just set to default. A more robust solution might queue warnings.
+			m.StaleTaskReclaimMultiplier = DefaultStaleTaskReclaimMultiplier
+		} else {
+			m.StaleTaskReclaimMultiplier = multiplier
+		}
+	}
+}

--- a/runner.go
+++ b/runner.go
@@ -61,7 +61,7 @@ func (m *Mgr) acquirePartitionTask(ctx context.Context) (PartitionInfo, error) {
 		// 优先处理Pending状态的分区
 		if partition.Status == StatusPending && partition.WorkerID == "" {
 			// 尝试锁定这个分区
-			lockKey := fmt.Sprintf(PartitionLockFmtFmt, m.Namespace, partitionID)
+			lockKey := fmt.Sprintf(PartitionLockKeyFormat, m.Namespace, partitionID) // Use global constant
 			locked, err := m.acquirePartitionLock(ctx, lockKey, partitionID)
 			if err != nil || !locked {
 				continue
@@ -71,27 +71,33 @@ func (m *Mgr) acquirePartitionTask(ctx context.Context) (PartitionInfo, error) {
 			partition.WorkerID = m.ID
 			partition.Status = StatusClaimed
 			partition.UpdatedAt = time.Now()
+			// Return the claimed partition
+			if err := m.updatePartitionStatus(ctx, partition); err != nil {
+				m.DataStore.ReleaseLock(ctx, lockKey, m.ID) // Release lock if update fails
+				return PartitionInfo{}, errors.Wrap(err, "更新新获取分区状态失败")
+			}
+			return partition, nil
+
 		} else if m.shouldReclaimPartition(partition) {
 			// 检查是否有长时间未更新的运行中分区（可能出现问题的分区）
-			// 注意：这里我们需要更加谨慎，只尝试获取明显过期的分区
-			lockKey := fmt.Sprintf(PartitionLockFmtFmt, m.Namespace, partitionID)
+			lockKey := fmt.Sprintf(PartitionLockKeyFormat, m.Namespace, partitionID) // Use global constant
 			locked, err := m.acquirePartitionLock(ctx, lockKey, partitionID)
 			if err != nil || !locked {
-				continue
+				continue // Failed to lock, try next partition
 			}
 
-			m.Logger.Infof("重新获取可能卡住的分区 %d，上次更新时间: %v",
-				partitionID, partition.UpdatedAt)
+			m.Logger.Infof("Reclaiming stale partition %d (status: %s, previously on worker: '%s', last updated: %v by worker: %s)",
+				partitionID, partition.Status, partition.WorkerID, partition.UpdatedAt.Format(time.RFC3339), m.ID)
 
-			// 重新获取该分区
+			// Re-claim the partition for the current worker
 			partition.WorkerID = m.ID
-			partition.Status = StatusClaimed
+			partition.Status = StatusClaimed // Set to Claimed first, will be Running by processPartitionTask
 			partition.UpdatedAt = time.Now()
 
 			if err := m.updatePartitionStatus(ctx, partition); err != nil {
 				// 如果更新失败，释放锁
-				m.DataStore.ReleaseLock(ctx, lockKey, m.ID)
-				return PartitionInfo{}, errors.Wrap(err, "更新分区状态失败")
+				m.DataStore.ReleaseLock(ctx, lockKey, m.ID) // Release lock if update fails
+				return PartitionInfo{}, errors.Wrap(err, "更新回收分区状态失败")
 			}
 
 			return partition, nil
@@ -119,14 +125,14 @@ func (m *Mgr) acquirePartitionLock(ctx context.Context, lockKey string, partitio
 
 // getPartitions 获取当前所有分区信息
 func (m *Mgr) getPartitions(ctx context.Context) (map[int]PartitionInfo, error) {
-	partitionInfoKey := fmt.Sprintf(PartitionInfoKeyFmt, m.Namespace)
+	partitionInfoKey := fmt.Sprintf(PartitionInfoKeyFormat, m.Namespace) // Use global constant
 	partitionsData, err := m.DataStore.GetPartitions(ctx, partitionInfoKey)
 	if err != nil {
 		return nil, err
 	}
 
 	if partitionsData == "" {
-		return nil, nil
+		return nil, nil // No partitions defined yet, not an error
 	}
 
 	var partitions map[int]PartitionInfo
@@ -137,65 +143,46 @@ func (m *Mgr) getPartitions(ctx context.Context) (map[int]PartitionInfo, error) 
 	return partitions, nil
 }
 
-// processPartitionTask 处理一个分区任务
-func (m *Mgr) processPartitionTask(ctx context.Context, task PartitionInfo) error {
-	m.Logger.Infof("开始处理分区 %d (ID范围: %d-%d)", task.PartitionID, task.MinID, task.MaxID)
-
-	// 更新分区状态为运行中
-	if err := m.updateTaskStatus(ctx, task, StatusRunning); err != nil {
-		return errors.Wrap(err, "更新分区状态为running失败")
+// _updateTaskStatusAndLog updates the task's status in the datastore and logs the change.
+func (m *Mgr) _updateTaskStatusAndLog(ctx context.Context, task PartitionInfo, newStatus string, operation string) error {
+	task.Status = newStatus
+	task.UpdatedAt = time.Now()
+	err := m.updatePartitionStatus(ctx, task) // updatePartitionStatus saves all partitions, which might be heavy.
+	if err != nil {
+		m.Logger.Errorf("Failed to update partition %d status to %s during %s: %v", task.PartitionID, newStatus, operation, err)
+		return errors.Wrapf(err, "updating partition status to %s failed during %s", newStatus, operation)
 	}
+	m.Logger.Infof("Partition %d status updated to %s after %s.", task.PartitionID, newStatus, operation)
+	return nil
+}
 
-	// 为长时间运行的任务创建心跳上下文
-	heartbeatCtx, cancelHeartbeat := context.WithCancel(context.Background())
+// _executeTaskWithHeartbeat encapsulates task execution with heartbeat and performance recording.
+func (m *Mgr) _executeTaskWithHeartbeat(ctx context.Context, task PartitionInfo) (processCount int64, err error) {
+	m.Logger.Debugf("Starting execution with heartbeat for partition %d", task.PartitionID)
+
+	// For long-running tasks, create a heartbeat context
+	heartbeatRunCtx, cancelHeartbeat := context.WithCancel(context.Background()) // Use background so it's not tied to incoming ctx directly for heartbeat
 	defer cancelHeartbeat()
 
-	// 启动心跳goroutine，定期更新分区状态
 	heartbeatDone := make(chan struct{})
 	go func() {
 		defer close(heartbeatDone)
-		m.runPartitionHeartbeat(heartbeatCtx, task)
+		m.runPartitionHeartbeat(heartbeatRunCtx, task) // runPartitionHeartbeat needs to use task info that might get stale
 	}()
 
-	// 准备处理选项并执行任务
-	processCount, err := m.executeProcessorTask(ctx, task)
-	m.Logger.Infof("分区 %d 处理完成: 处理项数=%d, 错误=%v", task.PartitionID, processCount, err)
-
-	// 停止心跳
-	cancelHeartbeat()
-	<-heartbeatDone
-
-	// 根据处理结果更新状态
-	newStatus := StatusCompleted
-	if err != nil {
-		newStatus = StatusFailed
-	}
-
-	// 更新任务状态并释放锁
-	if updateErr := m.updateTaskStatus(ctx, task, newStatus); updateErr != nil {
-		m.Logger.Errorf("更新分区 %d 状态为 %s 失败: %v",
-			task.PartitionID, newStatus, updateErr)
-	}
-
-	m.releasePartitionLock(ctx, task.PartitionID)
-
-	return err
-}
-
-// executeProcessorTask 执行处理器任务
-func (m *Mgr) executeProcessorTask(ctx context.Context, task PartitionInfo) (int64, error) {
-	// 记录任务开始时间，用于性能指标统计
+	// Record task start time for performance metrics
 	startTime := time.Now()
 
-	// 设置合理的处理超时时间，避免任务运行时间过长
-	// 默认使用分区锁过期时间的一半作为处理超时
+	// Setup task execution timeout
+	// Default to PartitionLockExpiry / 2. Consider making this configurable.
 	taskTimeout := m.PartitionLockExpiry / 2
+	if taskTimeout <= 0 { // Ensure positive timeout
+		taskTimeout = 30 * time.Minute // Fallback to a generous default if PartitionLockExpiry is very short or zero
+	}
+	execCtx, cancelExec := context.WithTimeout(ctx, taskTimeout) // This ctx is for the TaskProcessor.Process call
+	defer cancelExec()
 
-	// 创建带超时的上下文
-	execCtx, cancel := context.WithTimeout(ctx, taskTimeout)
-	defer cancel()
-
-	// 准备处理选项
+	// Prepare processor options
 	options := task.Options
 	if options == nil {
 		options = make(map[string]interface{})
@@ -203,61 +190,101 @@ func (m *Mgr) executeProcessorTask(ctx context.Context, task PartitionInfo) (int
 	options["partition_id"] = task.PartitionID
 	options["worker_id"] = m.ID
 
-	// 启动处理，并捕获上下文超时
+	// Execute the task
+	// This part is moved from the original executeProcessorTask
 	processDone := make(chan struct {
 		count int64
 		err   error
 	})
 
 	go func() {
-		count, err := m.TaskProcessor.Process(execCtx, task.MinID, task.MaxID, options)
-		select {
-		case <-execCtx.Done():
-			// 上下文已结束，无需发送结果
-		default:
-			processDone <- struct {
-				count int64
-				err   error
-			}{count, err}
-		}
+		pCount, pErr := m.TaskProcessor.Process(execCtx, task.MinID, task.MaxID, options)
+		// Ensure we don't write to processDone if execCtx is already done (avoiding panic on closed channel)
+		// However, processDone is read in a select, so it's generally safe.
+		// A check like `if execCtx.Err() == nil` before sending might be too restrictive if Process itself handles cancellation.
+		processDone <- struct {
+			count int64
+			err   error
+		}{pCount, pErr}
 	}()
-
-	// 等待处理完成或超时
-	var processCount int64 = 0
-	var processErr error
-
+	
 	select {
-	case <-ctx.Done():
-		processErr = ctx.Err()
-	case <-execCtx.Done():
+	// case <-ctx.Done(): // The parent context from processPartitionTask
+	// 	err = errors.Wrap(ctx.Err(), "parent context cancelled during task execution")
+	case <-execCtx.Done(): // Task execution context (with timeout)
 		if execCtx.Err() == context.DeadlineExceeded {
-			processErr = errors.New("任务处理超时")
+			err = errors.Errorf("task processing timed out after %v for partition %d", taskTimeout, task.PartitionID)
 		} else {
-			processErr = execCtx.Err()
+			err = errors.Wrapf(execCtx.Err(), "task execution context ended for partition %d", task.PartitionID)
 		}
 	case result := <-processDone:
 		processCount = result.count
-		processErr = result.err
+		err = result.err
 	}
 
-	// 记录任务性能指标
+	// Stop the heartbeat
+	cancelHeartbeat()
+	<-heartbeatDone // Wait for heartbeat goroutine to finish
+	m.Logger.Debugf("Heartbeat stopped for partition %d", task.PartitionID)
+
+	// Record task performance metrics if enabled
 	if m.UseTaskMetrics {
-		m.recordTaskPerformance(startTime, processCount, processErr, task.PartitionID)
+		m.recordTaskPerformance(startTime, processCount, err, task.PartitionID)
+	}
+	
+	m.Logger.Infof("Partition %d processing finished: items_processed=%d, error=%v", task.PartitionID, processCount, err)
+	return processCount, err
+}
+
+// processPartitionTask processes a single partition task using helper methods.
+func (m *Mgr) processPartitionTask(ctx context.Context, task PartitionInfo) error {
+	m.Logger.Infof("Beginning to process partition %d (ID range: %d-%d)", task.PartitionID, task.MinID, task.MaxID)
+
+	// 1. Update status to StatusRunning
+	if err := m._updateTaskStatusAndLog(ctx, task, StatusRunning, "task_start"); err != nil {
+		// If updating to running fails, we might not have the lock or there's a store issue.
+		// Release lock just in case we acquired it but failed to update status.
+		m.releasePartitionLock(ctx, task.PartitionID)
+		return err // Return error, task processing cannot proceed.
 	}
 
-	return processCount, processErr
-}
+	// 2. Call _executeTaskWithHeartbeat
+	// The context passed here (ctx) is the main context for this attempt to process the task.
+	// _executeTaskWithHeartbeat will create its own sub-contexts for timeout and heartbeat.
+	_, processErr := m._executeTaskWithHeartbeat(ctx, task)
 
-// updateTaskStatus 更新任务状态
-func (m *Mgr) updateTaskStatus(ctx context.Context, task PartitionInfo, status string) error {
-	task.Status = status
-	task.UpdatedAt = time.Now()
-	return m.updatePartitionStatus(ctx, task)
-}
+	// 3. Determine new status
+	finalStatus := StatusCompleted
+	if processErr != nil {
+		finalStatus = StatusFailed
+		// Log the specific processing error before updating status
+		m.Logger.Errorf("Error processing partition %d: %v", task.PartitionID, processErr)
+	}
 
+	// 4. Update status to finalStatus (StatusCompleted or StatusFailed)
+	// Use a background context for this final status update to ensure it happens even if the original ctx was cancelled.
+	// However, it's often better to use the original ctx if still valid, or a short-timeout ctx.
+	// For critical cleanup like this, a new short-lived context is often a good compromise.
+	updateCtx, cancelUpdate := context.WithTimeout(context.Background(), 10*time.Second) // Example timeout
+	defer cancelUpdate()
+	if updateErr := m._updateTaskStatusAndLog(updateCtx, task, finalStatus, "task_end"); updateErr != nil {
+		// Log this error, but the original processErr is more important to return to the caller.
+		m.Logger.Errorf("Critical: Failed to update final status for partition %d to %s: %v", task.PartitionID, finalStatus, updateErr)
+	}
+
+	// 5. Release partition lock
+	// Use a similar short-lived context for releasing lock.
+	releaseCtx, cancelRelease := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelRelease()
+	m.releasePartitionLock(releaseCtx, task.PartitionID)
+	
+	// 6. recordTaskPerformance is now called inside _executeTaskWithHeartbeat.
+
+	// Return the original error from the task processing itself.
+	return processErr
 // releasePartitionLock 释放分区锁
 func (m *Mgr) releasePartitionLock(ctx context.Context, partitionID int) {
-	lockKey := fmt.Sprintf(PartitionLockFmtFmt, m.Namespace, partitionID)
+	lockKey := fmt.Sprintf(PartitionLockKeyFormat, m.Namespace, partitionID) // Use global constant
 	if releaseErr := m.DataStore.ReleaseLock(ctx, lockKey, m.ID); releaseErr != nil {
 		m.Logger.Warnf("释放分区 %d 锁失败: %v", partitionID, releaseErr)
 	}
@@ -270,6 +297,10 @@ func (m *Mgr) updatePartitionStatus(ctx context.Context, task PartitionInfo) err
 	if err != nil {
 		return errors.Wrap(err, "获取分区信息失败")
 	}
+	if partitions == nil { // Ensure partitions map is initialized if no partitions were found
+		partitions = make(map[int]PartitionInfo)
+	}
+
 
 	// 更新特定分区
 	partitions[task.PartitionID] = task
@@ -280,7 +311,7 @@ func (m *Mgr) updatePartitionStatus(ctx context.Context, task PartitionInfo) err
 
 // savePartitions 保存分区信息到存储
 func (m *Mgr) savePartitions(ctx context.Context, partitions map[int]PartitionInfo) error {
-	partitionInfoKey := fmt.Sprintf(PartitionInfoKeyFmt, m.Namespace)
+	partitionInfoKey := fmt.Sprintf(PartitionInfoKeyFormat, m.Namespace) // Use global constant
 	updatedData, err := json.Marshal(partitions)
 	if err != nil {
 		return errors.Wrap(err, "编码更新后分区数据失败")
@@ -316,9 +347,11 @@ func (m *Mgr) handleTaskError(ctx context.Context, task PartitionInfo, processEr
 	m.Logger.Errorf("处理分区 %d 失败: %v", task.PartitionID, processErr)
 
 	// 更新分区状态为失败
-	task.Status = StatusFailed
-	if updateErr := m.updatePartitionStatus(ctx, task); updateErr != nil {
-		m.Logger.Warnf("更新分区状态失败: %v", updateErr)
+	// Use a short-timeout background context for this update attempt
+	updateCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if updateErr := m._updateTaskStatusAndLog(updateCtx, task, StatusFailed, "task_error_handling"); updateErr != nil {
+		m.Logger.Warnf("更新分区状态为失败也失败了: %v", updateErr)
 	}
 }
 
@@ -337,17 +370,49 @@ func (m *Mgr) handleAcquisitionError(err error) {
 // shouldReclaimPartition 判断一个分区是否应该被重新获取
 // 例如分区处于claimed/running状态但长时间未更新
 func (m *Mgr) shouldReclaimPartition(partition PartitionInfo) bool {
-	// 只检查Claimed或Running状态的分区
-	if !(partition.Status == StatusClaimed || partition.Status == StatusRunning) {
-		return false
+	// Only consider reclaiming partitions that are already Claimed or Running by *another* worker.
+	if partition.WorkerID == m.ID || (partition.Status != StatusClaimed && partition.Status != StatusRunning) {
+		return false // Not managed by another worker or not in a reclaimable state.
 	}
 
-	// 检查分区是否长时间未更新 (超过分区锁过期时间的3倍)
-	staleThreshold := m.PartitionLockExpiry * 3
+	// Ensure PartitionLockExpiry is positive to avoid issues with duration calculation.
+	// StaleTaskReclaimMultiplier should also be positive (enforced by the option func when setting it).
+	if m.PartitionLockExpiry <= 0 {
+		m.Logger.Warnf("PartitionLockExpiry is not positive (%v), cannot calculate stale threshold for partition %d. Skipping reclaim check.", m.PartitionLockExpiry, partition.PartitionID)
+		return false
+	}
+	
+	staleThresholdDuration := time.Duration(m.StaleTaskReclaimMultiplier * float64(m.PartitionLockExpiry))
+	
+	// It's useful to have a minimum practical stale threshold to prevent overly aggressive reclaiming
+	// if PartitionLockExpiry is configured to be very short. For example, at least 30 seconds.
+	minStaleThreshold := 30 * time.Second 
+	if staleThresholdDuration < minStaleThreshold {
+		m.Logger.Debugf("Calculated staleThresholdDuration %v for partition %d is less than minimum %v. Using minimum.", staleThresholdDuration, partition.PartitionID, minStaleThreshold)
+		staleThresholdDuration = minStaleThreshold
+	}
+
 	timeSinceUpdate := time.Since(partition.UpdatedAt)
 
-	// 如果分区更新时间太旧，并且不是本节点持有的，可以尝试重新获取
-	if timeSinceUpdate > staleThreshold && partition.WorkerID != m.ID {
+	m.Logger.Debugf(
+		"Evaluating partition %d for reclaim: Status=%s, UpdatedAt=%v (TimeSinceUpdate: %s), AssignedWorkerID=%s, CurrentEvaluatingWorkerID=%s, StaleThreshold=%s (Multiplier: %.2f, LockExpiry: %s)",
+		partition.PartitionID,
+		partition.Status,
+		partition.UpdatedAt.Format(time.RFC3339), // Log timestamp in a standard format
+		timeSinceUpdate.Round(time.Second),      // Log duration rounded to seconds
+		partition.WorkerID,
+		m.ID,
+		staleThresholdDuration.Round(time.Second), // Log duration rounded to seconds
+		m.StaleTaskReclaimMultiplier,
+		m.PartitionLockExpiry.Round(time.Second),  // Log duration rounded to seconds
+	)
+
+	if timeSinceUpdate > staleThresholdDuration {
+		m.Logger.Infof(
+			"Partition %d (assigned to worker '%s', status '%s', last updated %s ago) deemed STALE by worker '%s'. (StaleThreshold: %s)",
+			partition.PartitionID, partition.WorkerID, partition.Status, 
+			timeSinceUpdate.Round(time.Second), m.ID, staleThresholdDuration.Round(time.Second),
+		)
 		return true
 	}
 
@@ -357,32 +422,124 @@ func (m *Mgr) shouldReclaimPartition(partition PartitionInfo) bool {
 // runPartitionHeartbeat 为正在处理的分区任务发送心跳
 // 定期更新分区状态，防止任务被其他节点认为已死亡
 func (m *Mgr) runPartitionHeartbeat(ctx context.Context, task PartitionInfo) {
-	heartbeatTicker := time.NewTicker(m.PartitionLockExpiry / 3) // 确保心跳频率比锁过期时间更频繁
+	// Ensure PartitionLockExpiry is positive to avoid issues with ticker duration
+	if m.PartitionLockExpiry <= 0 {
+		m.Logger.Errorf("Cannot run partition heartbeat for partition %d: PartitionLockExpiry is not positive (%v).", task.PartitionID, m.PartitionLockExpiry)
+		return
+	}
+	heartbeatFrequency := m.PartitionLockExpiry / 3
+	if heartbeatFrequency <= 0 { // Safety for very short lock expiry
+		heartbeatFrequency = time.Second * 5 // Minimum heartbeat frequency
+	}
+
+	heartbeatTicker := time.NewTicker(heartbeatFrequency) 
 	defer heartbeatTicker.Stop()
 
-	// 记录上次更新时间，避免过于频繁的更新
-	lastUpdate := time.Now()
+	m.Logger.Debugf("Starting heartbeat for partition %d with frequency %v", task.PartitionID, heartbeatFrequency)
+
 
 	for {
 		select {
 		case <-ctx.Done():
+			m.Logger.Debugf("Stopping heartbeat for partition %d due to context cancellation: %v", task.PartitionID, ctx.Err())
 			return
 		case <-heartbeatTicker.C:
-			// 只有处理时间超过一定阈值才需要发送心跳
-			if time.Since(lastUpdate) >= m.PartitionLockExpiry/3 {
-				updateCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			// Create a short-lived context for the update operation itself.
+			// This context is derived from the heartbeat's main context (ctx).
+			updateCtx, cancelUpdate := context.WithTimeout(ctx, heartbeatFrequency/2) // Timeout for update op
 
-				// 更新分区时间戳，但保持状态不变
-				task.UpdatedAt = time.Now()
-				if err := m.updatePartitionStatus(updateCtx, task); err != nil {
-					m.Logger.Warnf("更新分区 %d 心跳失败: %v", task.PartitionID, err)
-				} else {
-					m.Logger.Debugf("已更新分区 %d 心跳", task.PartitionID)
-					lastUpdate = time.Now()
-				}
-
-				cancel()
+			// We need to refresh the task's UpdatedAt timestamp.
+			// It's crucial that updatePartitionStatus gets the *current* state of the partition
+			// and only updates the timestamp, or that we pass a task object that reflects this.
+			// The current `task` variable might be stale if other fields were meant to be updated.
+			// For a pure heartbeat, just updating UpdatedAt on a fresh fetch or a specific call is better.
+			// However, current updatePartitionStatus replaces the whole entry.
+			// A better approach might be a specific `UpdatePartitionHeartbeatTimestamp` method.
+			// For now, we make a copy and update its timestamp.
+			
+			currentPartitionInfo, err := m.getSpecificPartition(updateCtx, task.PartitionID)
+			if err != nil {
+				m.Logger.Warnf("Heartbeat for partition %d: failed to get current partition info: %v", task.PartitionID, err)
+				cancelUpdate()
+				continue
 			}
+			
+			// Only update if this worker still holds the claim and it's running
+			if currentPartitionInfo.WorkerID == m.ID && currentPartitionInfo.Status == StatusRunning {
+				currentPartitionInfo.UpdatedAt = time.Now()
+				if err := m.updatePartitionStatus(updateCtx, currentPartitionInfo); err != nil {
+					m.Logger.Warnf("Failed to update heartbeat for partition %d: %v", task.PartitionID, err)
+				} else {
+					m.Logger.Debugf("Heartbeat updated for partition %d at %s", task.PartitionID, currentPartitionInfo.UpdatedAt.Format(time.RFC3339))
+				}
+			} else {
+				m.Logger.Debugf("Heartbeat for partition %d skipped: worker ID (%s vs %s) or status (%s) mismatch.",
+					task.PartitionID, currentPartitionInfo.WorkerID, m.ID, currentPartitionInfo.Status)
+				// If the task is no longer running or claimed by this worker, the heartbeat can stop.
+				cancelUpdate()
+				return
+			}
+			cancelUpdate()
 		}
 	}
 }
+
+// getSpecificPartition is a helper to get a single partition's info, useful for heartbeats.
+func (m *Mgr) getSpecificPartition(ctx context.Context, partitionID int) (PartitionInfo, error) {
+    partitions, err := m.getPartitions(ctx)
+    if err != nil {
+        return PartitionInfo{}, err
+    }
+    if pInfo, ok := partitions[partitionID]; ok {
+        return pInfo, nil
+    }
+    return PartitionInfo{}, errors.Errorf("partition %d not found", partitionID)
+}
+
+// Helper constants (assuming these are defined elsewhere, e.g. model.go or mgr.go)
+// const (
+// 	StatusPending   = "pending"
+// 	StatusClaimed   = "claimed"
+// 	StatusRunning   = "running"
+// 	StatusCompleted = "completed"
+// 	StatusFailed    = "failed"
+//
+// 	PartitionLockFmtFmt = "elk_coord/%s/locks/partition/%d" // Will be replaced by PartitionLockKeyFormat
+// 	PartitionInfoKeyFmt = "elk_coord/%s/partitions_info" // Will be replaced by PartitionInfoKeyFormat
+// )
+//
+// var ErrNoAvailablePartition = errors.New("no available partition")
+//
+// const (
+// 	noTaskDelay        = 5 * time.Second
+// 	taskRetryDelay     = 10 * time.Second
+// 	taskCompletedDelay = 1 * time.Second
+// )
+//
+// type PartitionInfo struct {
+// 	PartitionID int                    `json:"partition_id"`
+// 	MinID       string                 `json:"min_id"`
+// 	MaxID       string                 `json:"max_id"`
+// 	Status      string                 `json:"status"`
+// 	WorkerID    string                 `json:"worker_id"`
+// 	UpdatedAt   time.Time              `json:"updated_at"`
+// 	Options     map[string]interface{} `json:"options"`
+// }
+//
+// // For TaskProcessor.Process method signature
+// type Processor interface {
+// 	Process(ctx context.Context, minID, maxID string, options map[string]interface{}) (int64, error)
+// }
+//
+// // For recordTaskPerformance
+// func (m *Mgr) recordTaskPerformance(startTime time.Time, count int64, err error, partitionID int) {
+// 	// Placeholder
+// }
+//
+// // For NewTaskWindow
+// func NewTaskWindow(m *Mgr) *TaskWindow {
+// 	// Placeholder
+// 	return nil
+// }
+// type TaskWindow struct{}
+// func (tw *TaskWindow) Start(ctx context.Context) {}


### PR DESCRIPTION
This commit includes a major refactoring of the coordinator service:

- Separated concerns from `mgr.go`:
    - Leader election logic moved to `leader_election.go` (new `LeaderElector` struct).
    - Node management (registration, heartbeats) moved to `node_manager.go` (new `NodeManager` struct).
    - Simplified logger initialization in `NewMgr`.

- Improved `runner.go`:
    - Broke down `processPartitionTask` into smaller, more focused private methods.
    - Clarified and enhanced stale task reclamation logic, making the reclaim threshold multiplier configurable and improving logging.

- Refactored `data/redis.go`:
    - `RedisDataStore` now expects full, prefixed keys from callers, removing internal prefixing logic and making it more generic.

- Standardized Key Management:
    - Centralized all Redis key format string constants into `constants/keys.go`.
    - Updated all relevant components (`Mgr`, `LeaderElector`, `NodeManager`, `runner.go`) to use these centralized constants and correctly construct full keys.
    - Adjusted `mgr.go`'s `getActiveWorkers` to parse node IDs from full keys.
    - Modified `node_manager.go` to use `data.DataStore` interface directly, removing type assertions.

These changes improve modularity, maintainability, and clarity of the codebase.